### PR TITLE
Update bazarr documentation for Sonarrv3

### DIFF
--- a/docs/applications/bazarr.mdx
+++ b/docs/applications/bazarr.mdx
@@ -39,7 +39,7 @@ Forgot your API key or port? No worries, here are one-liners you can submit from
 
 Sonarr:
 ```bash
-cat ~/.config/NzbDrone/config.xml | grep -e \<Api -e \<Port
+cat ~/.config/sonarr/config.xml | grep -e \<Api -e \<Port
 ```
 Radarr:
 ```bash


### PR DESCRIPTION
The command for getting the API key and Port was using the old path.