### PR TITLE
Let's also include the UrlBase since it's required

### DIFF
--- a/docs/applications/bazarr.mdx
+++ b/docs/applications/bazarr.mdx
@@ -39,11 +39,11 @@ Forgot your API key or port? No worries, here are one-liners you can submit from
 
 Sonarr:
 ```bash
-cat ~/.config/sonarr/config.xml | grep -e \<Api -e \<Port
+cat ~/.config/sonarr/config.xml | grep -e \<Api -e \<Port -e \<UrlBase
 ```
 Radarr:
 ```bash
-cat ~/.config/Radarr/config.xml | grep -e \<Api -e \<Port
+cat ~/.config/Radarr/config.xml | grep -e \<Api -e \<Port -e \<UrlBase
 ```
 :::
 


### PR DESCRIPTION
The bazarr install script does this, so we could not it for the manual setup too