### PR TITLE
fix branch names

### DIFF
--- a/docs/applications/deluge.mdx
+++ b/docs/applications/deluge.mdx
@@ -30,7 +30,7 @@ If you intend to use the thin client with your installation, your local version 
 #### Unattended variables
 When installing Deluge, you may specify the variable `DELUGE_VERSION` to bypass the version popup. Accepted values are:
 - `repo` -- Will install Deluge from your OS repository
-- `stable-1.3` -- Will compile Deluge from the head of the stable-1.3 branch (1.3.15)
+- `1.3-stable` -- Will compile Deluge from the head of the 1.3-stable branch (1.3.15)
 - `master` -- Will compile Deluge from the head of the master branch (2.0)
 
 #### Libtorrent Patching


### PR DESCRIPTION
Fixes branch names of stable-1.3 to 1.3-stable, as per https://github.com/deluge-torrent/deluge/tree/1.3-stable