### PR TITLE
add key signature for x2go package

### DIFF
--- a/docs/applications/x2go.mdx
+++ b/docs/applications/x2go.mdx
@@ -10,6 +10,7 @@ X2Go is an open source remote desktop software for Linux that uses the NX techno
 
 
 ```bash main
+sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com E1F958385BFE2B6E
 sudo box install x2go
 ```
 


### PR DESCRIPTION
I needed the repository archive key from X2GO to install on debian 10.

[From the X2GO Wiki:](https://wiki.x2go.org/doku.php/wiki:repositories:debian)
Please switch to a user which has administrator privileges on your system in your preferred command line client:

`su -`

or

`sudo -s`

The following command will ensure that your system will be able to work with the repository archive key.

`apt-key adv --recv-keys --keyserver keyserver.ubuntu.com E1F958385BFE2B6E`