### PR TITLE
sab-fix in conn4arr

### DIFF
--- a/docs/snippets/conn4arr.mdx
+++ b/docs/snippets/conn4arr.mdx
@@ -49,7 +49,7 @@ nzbget username: <your username>
 nzbget Password: <your password>
 Add label to torrent: Series (or anything else you desire)
 * label must exist under Categories in nzbGet" lang="plaintext"></CodeBlock></TabItem>
-   <TabItem value="rutorrent"><CodeBlock children="Name: rTorrent
+   <TabItem value="sabnzbd"><CodeBlock children="Name: SABnzbd
 Host: 127.0.0.1
 Port: sabnzbd port
 URL Path: BLANK


### PR DESCRIPTION
SABnzbd info is showing under the ruTorrent tab instead of it's own tab. I believe this should fix the issue.