### PR TITLE
add info about valid swizzin user

### DIFF
--- a/docs/getting-started/home.mdx
+++ b/docs/getting-started/home.mdx
@@ -56,8 +56,8 @@ When finished, the installer will ask you a few questions:
 
 :::caution Valid username
 
-When you create the swizzin master user or any additionnal user, do not use the username that you used to connect to the server threw SSH.
-When you add an user threw swizzin, it creates a Linux user, so using the same username twice may prevent you to connect threw SSH again.
+When you create the Swizzin master user or any additional user, do not use the username that you used to connect to the server threw SSH.
+When you add a user through Swizzin, it creates a Linux user, so using the same username twice may prevent you from connecting through SSH again.
 :::
 
 In text fields, you only need to enter your text and hit `return` to enter. To choose packages, from the list, you can navigate with the arrow keys. Press `space` to select an entry. When you're satisfied with your selection, press `tab` to move the selector to `Ok` and then press enter. This will advance the screen.

--- a/docs/getting-started/home.mdx
+++ b/docs/getting-started/home.mdx
@@ -54,6 +54,12 @@ When finished, the installer will ask you a few questions:
 - A password for the master user
 - The packages you would like to install
 
+:::caution Valid username
+
+When you create the swizzin master user or any additionnal user, do not use the username that you used to connect to the server threw SSH.
+When you add an user threw swizzin, it creates a Linux user, so using the same username twice may prevent you to connect threw SSH again.
+:::
+
 In text fields, you only need to enter your text and hit `return` to enter. To choose packages, from the list, you can navigate with the arrow keys. Press `space` to select an entry. When you're satisfied with your selection, press `tab` to move the selector to `Ok` and then press enter. This will advance the screen.
 
 When you have finished running through the prompts, installation will start. The time it takes will depend on the number of packages you have selected.


### PR DESCRIPTION
I had some trouble to setup swizzin.

I found out that re-using the admin account as the master user was not a good idea, as I could not open SSH connection after that. It's way more ok to create additionnal user than reusing the main admin account that I used to administrate the server