### PR TITLE
Add rtorrent patching process

### DIFF
--- a/docs/applications/rtorrent.mdx
+++ b/docs/applications/rtorrent.mdx
@@ -21,6 +21,20 @@ Before installation, you'll receive a prompt asking you which version of rTorren
 
 After installation, there will be two 3 new packages installed: xmlrpc-c, libtorrent-rakshasa, and rtorrent. Due to potential packaging conflicts with your distribution's repository, the package `rtorrent` has been held by apt and will not be marked for upgrade. You may see apt issue a warning regarding the held `rtorrent` package. This is completely normal and it means the apt mark is working as expected.
 
+#### Patching
+If you would like to patch the rTorrent or libtorrent-rakshasa source, the rTorrent compile will check if `/root/libtorrent-rakshasa-{libtorrentver}.patch` and `/root/rtorrent-{rtorrentver}.patch` exist. If they do, then the installer will automatically patch the rTorrent and/or libtorrent-rakshasa source with these patches before they are compiled.
+
+Note that libtorrent-rakshasa (used by rTorrent) is a different library than libtorrent-rasterbar (used by Deluge and qBittorrent). For details on how to patch libtorrent-rasterbar, refer to the [Deluge](/applications/deluge#libtorrent-patching) and [qBittorrent](/applications/qbittorrent#libtorrent-patching) pages.
+
+Examples of valid patch filenames are:
+
+```
+/root/libtorrent-rakshasa-0.13.8.patch
+/root/rtorrent-0.9.8.patch
+```
+
+You must supply your own patches!
+
 ## How to upgrade/downgrade
 
 rTorrent has a upgrade helper script in `box`. To access the function, use the command:


### PR DESCRIPTION
This change documents the rtorrent patching process added in https://github.com/swizzin/swizzin/commit/6753ec81aca7f901192609d088f6d5a131d015b7. I'm happy to make any desired changes. It shouldn't be merged until the next release I guess.